### PR TITLE
Add admin menu to WinShirt plugin

### DIFF
--- a/winshirt/winshirt.php
+++ b/winshirt/winshirt.php
@@ -13,3 +13,30 @@ require_once plugin_dir_path(__FILE__) . 'includes/api-routes.php';
 require_once plugin_dir_path(__FILE__) . 'includes/personalization-functions.php';
 require_once plugin_dir_path(__FILE__) . 'includes/stripe-integration.php';
 require_once plugin_dir_path(__FILE__) . 'includes/admin-pages.php';
+
+/**
+ * Ajoute le menu WinShirt dans l'admin WordPress.
+ */
+function winshirt_register_admin_menu() {
+    add_menu_page(
+        'WinShirt',
+        'WinShirt',
+        'manage_options',
+        'winshirt-dashboard',
+        'winshirt_render_dashboard',
+        'dashicons-tshirt',
+        25
+    );
+}
+add_action( 'admin_menu', 'winshirt_register_admin_menu' );
+
+/**
+ * Affiche la page de tableau de bord temporaire.
+ */
+function winshirt_render_dashboard() {
+    echo '<div class="wrap">';
+    echo '<h1>🎨 Tableau de bord WinShirt</h1>';
+    echo '<p>Bienvenue dans le plugin de personnalisation produit avec loterie. L’interface arrive bientôt !</p>';
+    echo '</div>';
+}
+


### PR DESCRIPTION
## Summary
- hook admin_menu to register a WinShirt menu
- implement a simple dashboard callback

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_684f22ebc9688329b4414f57afdbff89