### PR TITLE
Fix SFTP deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,13 +13,12 @@ jobs:
         uses: actions/checkout@v3
 
       - name: 🚀 Upload via SFTP
-        uses: appleboy/scp-action@v0.1.4
+        uses: SamKirkland/FTP-Deploy-Action@v4
         with:
-          host: home408430562.1and1-data.host
+          server: home408430562.1and1-data.host
           username: ${{ secrets.FTP_USERNAME }}
           password: ${{ secrets.FTP_PASSWORD }}
+          protocol: sftp
           port: 22
-          source: "winshirt/**"
-          target: "/Winshirt/wp-content/plugins/winshirt/"
-          overwrite: true
-          strip_components: 0
+          local-dir: winshirt/
+          server-dir: /Winshirt/wp-content/plugins/winshirt/


### PR DESCRIPTION
## Summary
- use an SFTP deployment action

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f2b0c86908329bb9e1cecd03d54e6