### PR TITLE
Fix SFTP deployment path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,6 @@ jobs:
           username: ${{ secrets.FTP_USERNAME }}
           password: ${{ secrets.FTP_PASSWORD }}
           protocol: sftp
-          local-dir: ./winshirt/
-          server-dir: /Winshirt/wp-content/plugins/winshirt/
+          local-dir: ./winshirt
+          server-dir: Winshirt/wp-content/plugins/winshirt
           log-level: verbose


### PR DESCRIPTION
## Summary
- avoid creating an extra `winshirt` folder on deploy

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684f2f84db4083299e6add46a0c5d1d5