### PR TITLE
Add dynamic mockup generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # Module-Wordpress V1.1
+
+This plugin provides the basic WinShirt admin area. Version 1.1 introduces a simple mockup generator that lets you create color variations from a single PNG image.
+
+## Mockup Generator
+
+1. Upload a neutral PNG (transparent background) in the **Mockup Generator** submenu.
+2. Enter one or more HEX colors separated by comma or space.
+3. The preview area displays canvases tinted with each color, allowing quick creation of colour variants without generating multiple images.

--- a/winshirt/assets/js/mockup-generator.js
+++ b/winshirt/assets/js/mockup-generator.js
@@ -1,0 +1,35 @@
+jQuery(document).ready(function($){
+    function parseColors(){
+        var val = $('#winshirt_mockup_colors').val() || '';
+        return val.split(/[,\s]+/).filter(Boolean);
+    }
+
+    function renderMockups(){
+        var src = $('#winshirt_mockup_image_preview').attr('src');
+        var colors = parseColors();
+        var container = $('#winshirt_mockup_result');
+        container.empty();
+        if(!src){
+            return;
+        }
+        colors.forEach(function(color){
+            var canvas = $('<canvas class="winshirt-mockup-canvas"></canvas>')[0];
+            var ctx = canvas.getContext('2d');
+            var img = new Image();
+            img.onload = function(){
+                canvas.width = img.width;
+                canvas.height = img.height;
+                ctx.drawImage(img, 0, 0);
+                ctx.globalCompositeOperation = 'source-in';
+                ctx.fillStyle = color;
+                ctx.fillRect(0, 0, canvas.width, canvas.height);
+            };
+            img.src = src;
+            container.append(canvas);
+        });
+    }
+
+    $('#winshirt_mockup_colors').on('input', renderMockups);
+    $(document).on('winshirtImageSelected', renderMockups);
+    renderMockups();
+});

--- a/winshirt/includes/mockup-generator.php
+++ b/winshirt/includes/mockup-generator.php
@@ -1,0 +1,111 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Register mockup settings.
+ */
+function winshirt_register_mockup_settings() {
+    register_setting( 'winshirt_mockup_options', 'winshirt_mockup_image' );
+    register_setting( 'winshirt_mockup_options', 'winshirt_mockup_colors' );
+}
+add_action( 'admin_init', 'winshirt_register_mockup_settings' );
+
+/**
+ * Add submenu page for mockups.
+ */
+function winshirt_register_mockup_submenu() {
+    add_submenu_page(
+        'winshirt',
+        __( 'Mockup Generator', 'winshirt' ),
+        __( 'Mockup Generator', 'winshirt' ),
+        'manage_options',
+        'winshirt-mockups',
+        'winshirt_render_mockup_page'
+    );
+}
+add_action( 'admin_menu', 'winshirt_register_mockup_submenu' );
+
+/**
+ * Enqueue admin assets.
+ */
+function winshirt_mockup_admin_assets( $hook ) {
+    if ( $hook !== 'toplevel_page_winshirt' && $hook !== 'winshirt_page_winshirt-mockups' ) {
+        return;
+    }
+    wp_enqueue_media();
+    wp_enqueue_script( 'winshirt-mockup', WINSHIRT_URL . 'assets/js/mockup-generator.js', array( 'jquery' ), '1.0', true );
+}
+add_action( 'admin_enqueue_scripts', 'winshirt_mockup_admin_assets' );
+
+/**
+ * Render mockup settings page.
+ */
+function winshirt_render_mockup_page() {
+    $image  = get_option( 'winshirt_mockup_image', '' );
+    $colors = get_option( 'winshirt_mockup_colors', '' );
+    ?>
+    <div class="wrap">
+        <h1><?php esc_html_e( 'Mockup Generator', 'winshirt' ); ?></h1>
+        <form method="post" action="options.php">
+            <?php
+            settings_fields( 'winshirt_mockup_options' );
+            do_settings_sections( 'winshirt_mockup_options' );
+            ?>
+            <table class="form-table" role="presentation">
+                <tr>
+                    <th scope="row">
+                        <label for="winshirt_mockup_image"><?php esc_html_e( 'Base PNG Image', 'winshirt' ); ?></label>
+                    </th>
+                    <td>
+                        <input type="text" id="winshirt_mockup_image" name="winshirt_mockup_image" value="<?php echo esc_attr( $image ); ?>" class="regular-text" />
+                        <button type="button" class="button" id="winshirt_mockup_image_button"><?php esc_html_e( 'Select Image', 'winshirt' ); ?></button>
+                        <?php if ( $image ) : ?>
+                            <div><img id="winshirt_mockup_image_preview" src="<?php echo esc_url( $image ); ?>" style="max-width:150px;" /></div>
+                        <?php else : ?>
+                            <div><img id="winshirt_mockup_image_preview" style="max-width:150px; display:none;" /></div>
+                        <?php endif; ?>
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row">
+                        <label for="winshirt_mockup_colors"><?php esc_html_e( 'HEX Colors', 'winshirt' ); ?></label>
+                    </th>
+                    <td>
+                        <textarea id="winshirt_mockup_colors" name="winshirt_mockup_colors" rows="5" cols="30" class="large-text code"><?php echo esc_textarea( $colors ); ?></textarea>
+                        <p class="description"><?php esc_html_e( 'Enter colors separated by comma or space.', 'winshirt' ); ?></p>
+                    </td>
+                </tr>
+            </table>
+            <?php submit_button(); ?>
+        </form>
+        <h2><?php esc_html_e( 'Preview', 'winshirt' ); ?></h2>
+        <div id="winshirt_mockup_result" style="display:flex; gap:10px; flex-wrap: wrap;"></div>
+    </div>
+    <script>
+    jQuery(document).ready(function($){
+        var frame;
+        $('#winshirt_mockup_image_button').on('click', function(e){
+            e.preventDefault();
+            if(frame){
+                frame.open();
+                return;
+            }
+            frame = wp.media({
+                title: '<?php echo esc_js( __( 'Select or Upload PNG', 'winshirt' ) ); ?>',
+                button: { text: '<?php echo esc_js( __( 'Use this image', 'winshirt' ) ); ?>' },
+                multiple: false
+            });
+            frame.on('select', function(){
+                var attachment = frame.state().get('selection').first().toJSON();
+                $('#winshirt_mockup_image').val(attachment.url);
+                $('#winshirt_mockup_image_preview').attr('src', attachment.url).show();
+                $(document).trigger('winshirtImageSelected');
+            });
+            frame.open();
+        });
+    });
+    </script>
+    <?php
+}

--- a/winshirt/winshirt.php
+++ b/winshirt/winshirt.php
@@ -20,4 +20,5 @@ if ( ! defined( 'WINSHIRT_URL' ) ) {
 
 // Include core plugin files.
 require_once WINSHIRT_PATH . 'includes/admin-menu.php';
+require_once WINSHIRT_PATH . 'includes/mockup-generator.php';
 


### PR DESCRIPTION
## Summary
- add mockup generator submenu to WinShirt
- use base PNG and HEX colors to preview color variants
- include JS to render canvases with color overlays
- document new functionality

## Testing
- `php -l winshirt/includes/mockup-generator.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c830e8c0c8329b7a556344282daed